### PR TITLE
Update pod spec for tvOS support

### DIFF
--- a/SKTiled.podspec
+++ b/SKTiled.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.13'
+  s.tvos.deployment_target = '11.0'
   s.source                = { :git => "https://github.com/mfessenden/SKTiled.git", :tag => s.version }
 
   s.source_files          = 'Sources/*.swift'


### PR DESCRIPTION
The pod spec didn't include tvOS support, so I couldn't include it in my tvOS project. Seems to work fine with this change, but not sure what you want the minimum supported tvOS version to be.